### PR TITLE
Add permissions section to GitHub Actions workflow for release

### DIFF
--- a/.github/workflows/release-on-prod.yml
+++ b/.github/workflows/release-on-prod.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - release
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Include a permissions section in the GitHub Actions workflow to allow write access to contents during the release process.